### PR TITLE
feat(babel): add React preset to Babel configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-eslint": "^8.2.1",
     "babel-jest": "^22.1.0",
     "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "chalk": "^2.3.0",
     "common-tags": "^1.7.2",

--- a/src/config/__tests__/babelrc.js
+++ b/src/config/__tests__/babelrc.js
@@ -1,0 +1,27 @@
+afterEach(() => {
+  jest.resetModules()
+})
+
+test('includes babel-preset-react when react is a dependency', () => {
+  const utils = require('../../utils')
+  Object.assign(utils, {
+    hasAnyDep: arg => arg === 'react',
+  })
+  const config = require('../babelrc')
+
+  expect(config.presets).toEqual(
+    expect.arrayContaining([expect.stringMatching(/babel-preset-react/)])
+  )
+})
+
+test('does not include babel-preset-react when react is not a dependency', () => {
+  const utils = require('../../utils')
+  Object.assign(utils, {
+    hasAnyDep: () => false,
+  })
+  const config = require('../babelrc')
+
+  expect(config.presets).not.toEqual(
+    expect.arrayContaining([expect.stringMatching(/babel-preset-react/)])
+  )
+})

--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -1,6 +1,19 @@
+const { hasAnyDep, parseEnv } = require('../utils')
+
+const isTest = (process.env.BABEL_ENV || process.env.NODE_ENV) === 'test'
+const isRollup = parseEnv('BUILD_ROLLUP', false)
+const treeshake = parseEnv('BUILD_TREESHAKE', isRollup)
+
+const envModules = treeshake ? { modules: false } : {}
+const envTargets = isTest
+  ? { node: 'current' }
+  : isRollup ? { browsers: ['ie 10', 'ios 7'] } : { node: 8 }
+const envOptions = Object.assign({}, envModules, { targets: envTargets })
+
 module.exports = {
   presets: [
-    [require.resolve('babel-preset-env'), { targets: { node: '8' } }],
+    [require.resolve('babel-preset-env'), envOptions],
     require.resolve('babel-preset-stage-2'),
-  ],
+    hasAnyDep('react') && require.resolve('babel-preset-react'),
+  ].filter(Boolean),
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,6 +24,21 @@ const hasAnyDep = args => [hasDep, hasDevDep, hasPeerDep].some(fn => fn(args))
 
 const isHelp = arg => arg === '--help' || arg === '-h'
 
+function parseEnv(name, def) {
+  if (envIsSet(name)) {
+    return JSON.parse(process.env[name])
+  }
+  return def
+}
+
+function envIsSet(name) {
+  return (
+    process.env.hasOwnProperty(name) &&
+    process.env[name] &&
+    process.env[name] !== 'undefined'
+  )
+}
+
 function resolveBin(
   modName,
   { executable = modName, cwd = process.cwd() } = {}
@@ -62,6 +77,7 @@ function resolveMduScripts() {
 module.exports = {
   appDirectory,
   fromRoot,
+  parseEnv,
   hasFile,
   hasPkgProp,
   hasAnyDep,

--- a/yarn.lock
+++ b/yarn.lock
@@ -458,6 +458,14 @@ babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-helper-builder-react-jsx@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz#39ff8313b75c8b65dceff1f31d383e0ff2a408a0"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    esutils "^2.0.2"
+
 babel-helper-call-delegate@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
@@ -614,6 +622,14 @@ babel-plugin-syntax-dynamic-import@^6.18.0:
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+
+babel-plugin-syntax-flow@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+
+babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
 babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -834,12 +850,47 @@ babel-plugin-transform-exponentiation-operator@^6.22.0, babel-plugin-transform-e
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-flow-strip-types@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
+  dependencies:
+    babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-object-rest-spread@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.26.0"
+
+babel-plugin-transform-react-display-name@^6.23.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-self@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-source@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz#66ac12153f5cd2d17b3c19268f4bf0197f44ecd6"
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz#840a028e7df460dfc3a2d29f0c0d91f6376e66a3"
+  dependencies:
+    babel-helper-builder-react-jsx "^6.24.1"
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
@@ -897,12 +948,29 @@ babel-preset-env@^1.6.1:
     invariant "^2.2.2"
     semver "^5.3.0"
 
+babel-preset-flow@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
+  dependencies:
+    babel-plugin-transform-flow-strip-types "^6.22.0"
+
 babel-preset-jest@^22.1.0:
   version "22.1.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.1.0.tgz#ff4e704102f9642765e2254226050561d8942ec9"
   dependencies:
     babel-plugin-jest-hoist "^22.1.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
+
+babel-preset-react@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
+  dependencies:
+    babel-plugin-syntax-jsx "^6.3.13"
+    babel-plugin-transform-react-display-name "^6.23.0"
+    babel-plugin-transform-react-jsx "^6.24.1"
+    babel-plugin-transform-react-jsx-self "^6.22.0"
+    babel-plugin-transform-react-jsx-source "^6.22.0"
+    babel-preset-flow "^6.23.0"
 
 babel-preset-stage-2@^6.24.1:
   version "6.24.1"


### PR DESCRIPTION
If a project contains React as a dependency, the default Babel configuration will include babel-preset-react as a preset.

BREAKING CHANGE: In order to properly support treeshaking in babel-preset-env's options, environment variables BUILD_ROLLUP and BUILD_TREESHAKE were added in order to explicitly support those features. As such, any projects using the `mdu-scripts build` script for Rollup builds will need to set `BUILD_ROLLUP=true` in their script command. For example:

```sh
BUILD_ROLLUP=true mdu-scripts build
```

Resolves #17